### PR TITLE
Fix Enum Getter Generation for Longs

### DIFF
--- a/dtonator/src/main/java/com/bizo/dtonator/config/TypeUtils.java
+++ b/dtonator/src/main/java/com/bizo/dtonator/config/TypeUtils.java
@@ -1,0 +1,15 @@
+package com.bizo.dtonator.config;
+
+public class TypeUtils {
+
+  public static String formatForCodeGeneration(final Object value, final Class<?> type) {
+    if (type.equals(Integer.class)) {
+      return value.toString();
+    } else if (type.equals(Long.class)) {
+      return value.toString() + "L";
+    } else {
+      return "\"" + value.toString() + "\"";
+    }
+  }
+
+}


### PR DESCRIPTION
The was an issue with return types when I tested with b360-web. Now, it will support String, Long, Integer, and anything will default to String and call object.toString().
